### PR TITLE
lp-depot - HTTP/1.1, Sony and Uplay, Slice config building blocks

### DIFF
--- a/lp-base/tasks/system.yml
+++ b/lp-base/tasks/system.yml
@@ -14,12 +14,14 @@
 - name: System | Set Hostname
   hostname:
     name: "{{ inventory_hostname }}.{{ domains.lan }}"
+  when: ansible_virtualization_type != 'lxc'
   tags: [ 'hostname' ]
 
 - name: System | Persist Hostname
   copy:
     dest: /etc/hostname
     content: "{{ inventory_hostname }}.{{ domains.lan }}"
+  when: ansible_virtualization_type != 'lxc'
   tags: [ 'hostname' ]
 
 - name: System | Modify Grub Boot Delay

--- a/lp-depot/defaults/main.yml
+++ b/lp-depot/defaults/main.yml
@@ -34,7 +34,16 @@ depot_sites:
     size: 5g
     domains:
       - l3cdn.riotgames.com
+      - worldwide.l3cdn.riotgames.com
       - news.cdn.leagueoflegends.com
+  sony:
+    size: 100g
+    domains:
+      - pls.patch.station.sony.com
+  uplay:
+    size: 100g
+    domains:
+      - cdn.ubi.com
   windows:
     size: 20g
     domains:

--- a/lp-depot/defaults/main.yml
+++ b/lp-depot/defaults/main.yml
@@ -43,7 +43,7 @@ depot_sites:
   uplay:
     size: 100g
     domains:
-      - cdn.ubi.com
+      - uplaypc-s-ubisoft.cdn.ubi.com
   windows:
     size: 20g
     domains:

--- a/lp-depot/tasks/configure.yml
+++ b/lp-depot/tasks/configure.yml
@@ -26,6 +26,8 @@
   with_items:
     - proxy-cache
     - proxy-pass
+    - proxy-slice
+    - proxy-noslice
   notify: reload nginx
 
 - name: Depot | Render Site Templates

--- a/lp-depot/tasks/main.yml
+++ b/lp-depot/tasks/main.yml
@@ -9,4 +9,5 @@
   tags: [ 'run' ]
 
 - include: consul.yml
+  when: consul_agent_enable | default(false) == true
   tags: [ 'consul' ]

--- a/lp-depot/templates/blizzard.site.j2
+++ b/lp-depot/templates/blizzard.site.j2
@@ -10,21 +10,11 @@ server {
   resolver {{ depot_resolvers | join(" ") }};
 
   location / {
-    # Request Slicing
-    # Supported in nginx 1.9.8
-    slice 1m;
-
     # Cache Location
     proxy_cache blizzard;
 
-    # Cache Settings
-    proxy_cache_valid 200 206 7d;
-
-    proxy_cache_key   $uri$slice_range;
-    proxy_set_header  Range $slice_range;
-
-    # Issue #14
-    proxy_hide_header ETag;
+    # Use slicing method for this site
+    include depot/proxy-slice.conf;
 
     # Use proxy_cache method
     include depot/proxy-cache.conf;

--- a/lp-depot/templates/blizzard.site.j2
+++ b/lp-depot/templates/blizzard.site.j2
@@ -10,13 +10,10 @@ server {
   resolver {{ depot_resolvers | join(" ") }};
 
   location / {
-    # Cache Location
     proxy_cache blizzard;
 
-    # Use slicing method for this site
     include depot/proxy-slice.conf;
 
-    # Use proxy_cache method
     include depot/proxy-cache.conf;
     include depot/proxy-pass.conf;
   }

--- a/lp-depot/templates/origin.site.j2
+++ b/lp-depot/templates/origin.site.j2
@@ -10,18 +10,14 @@ server {
   resolver {{ depot_resolvers | join(" ") }};
 
   location / {
-    # Request Slicing
-    # Supported in nginx 1.9.8
-    slice 1m;
-
     # Cache Location
     proxy_cache origin;
 
+    # Use slicing method for this site
+    include depot/proxy-slice.conf;
+
     # Cache Settings
     proxy_ignore_headers Expires Cache-Control;
-    proxy_cache_key   $uri$slice_range;
-    proxy_cache_valid 200 206 7d;
-    proxy_set_header  Range $slice_range;
 
     # Use proxy_cache method
     include depot/proxy-cache.conf;

--- a/lp-depot/templates/origin.site.j2
+++ b/lp-depot/templates/origin.site.j2
@@ -10,16 +10,13 @@ server {
   resolver {{ depot_resolvers | join(" ") }};
 
   location / {
-    # Cache Location
     proxy_cache origin;
 
-    # Use slicing method for this site
     include depot/proxy-slice.conf;
 
-    # Cache Settings
+    # Extra Cache Settings
     proxy_ignore_headers Expires Cache-Control;
 
-    # Use proxy_cache method
     include depot/proxy-cache.conf;
     include depot/proxy-pass.conf;
   }

--- a/lp-depot/templates/proxy-noslice.conf.j2
+++ b/lp-depot/templates/proxy-noslice.conf.j2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+
+# Cache Settings
+proxy_cache_key   $uri;
+proxy_cache_valid 200 7d;

--- a/lp-depot/templates/proxy-pass.conf.j2
+++ b/lp-depot/templates/proxy-pass.conf.j2
@@ -1,5 +1,9 @@
 # {{ ansible_managed }}
 
+# Offer keepalive connections to clients that want to make use of them
+# Greatly improves efficiency across the board for larger deployments
+proxy_http_version 1.1;
+
 # Keep a client-side HTTP/1.1 alive until closed by the client
 # This is to work around buggy clients not expecting a "Connection: close"
 # after 100 requests and not bothering to re-initiate (Blizzard Web Client)

--- a/lp-depot/templates/proxy-pass.conf.j2
+++ b/lp-depot/templates/proxy-pass.conf.j2
@@ -11,6 +11,10 @@ proxy_pass http://$host$request_uri;
 proxy_redirect off;
 proxy_ignore_client_abort on;
 
+# Issue #14 - Blizzard downloads halting
+# This also impacts Origin, so we disable ETags across the board
+proxy_hide_header ETag;
+
 # Upstream request headers
 proxy_set_header Host $host;
 proxy_set_header X-Real-IP $remote_addr;

--- a/lp-depot/templates/proxy-slice.conf.j2
+++ b/lp-depot/templates/proxy-slice.conf.j2
@@ -1,0 +1,9 @@
+# {{ ansible_managed }}
+
+# Request slicing, supported since nginx 1.9.8
+slice 1m;
+
+# Cache Settings
+proxy_cache_key   $uri$slice_range;
+proxy_cache_valid 200 206 7d;
+proxy_set_header  Range $slice_range;

--- a/lp-depot/templates/riot.site.j2
+++ b/lp-depot/templates/riot.site.j2
@@ -10,13 +10,10 @@ server {
   resolver {{ depot_resolvers | join(" ") }};
 
   location / {
-    # Cache Location
     proxy_cache riot;
 
-    # No slicing for this site
     include depot/proxy-noslice.conf;
 
-    # Use proxy_cache method
     include depot/proxy-cache.conf;
     include depot/proxy-pass.conf;
   }

--- a/lp-depot/templates/riot.site.j2
+++ b/lp-depot/templates/riot.site.j2
@@ -10,10 +10,11 @@ server {
   resolver {{ depot_resolvers | join(" ") }};
 
   location / {
-    # Cache location
+    # Cache Location
     proxy_cache riot;
-    proxy_cache_key "$uri";
-    proxy_cache_valid 200 7d;
+
+    # No slicing for this site
+    include depot/proxy-noslice.conf;
 
     # Use proxy_cache method
     include depot/proxy-cache.conf;

--- a/lp-depot/templates/sony.site.j2
+++ b/lp-depot/templates/sony.site.j2
@@ -1,0 +1,26 @@
+# {{ ansible_managed }}
+
+server {
+  listen 80;
+  server_name .{{ depot_sites.sony.domains | join(" .") }};
+
+  access_log {{ depot_logdir }}/sony/depot-access.log depot buffer=128k flush=1m;
+  error_log {{ depot_logdir }}/sony/depot-error.log;
+
+  resolver {{ depot_resolvers | join(" ") }};
+
+  location / {
+    # Cache Location
+    proxy_cache sony;
+
+    # Use slicing method for this site
+    include depot/proxy-slice.conf;
+
+    # Extra Cache Settings
+    proxy_ignore_headers Expires Cache-Control;
+
+    # Use proxy_cache method
+    include depot/proxy-cache.conf;
+    include depot/proxy-pass.conf;
+  }
+}

--- a/lp-depot/templates/sony.site.j2
+++ b/lp-depot/templates/sony.site.j2
@@ -10,16 +10,13 @@ server {
   resolver {{ depot_resolvers | join(" ") }};
 
   location / {
-    # Cache Location
     proxy_cache sony;
 
-    # Use slicing method for this site
     include depot/proxy-slice.conf;
 
     # Extra Cache Settings
     proxy_ignore_headers Expires Cache-Control;
 
-    # Use proxy_cache method
     include depot/proxy-cache.conf;
     include depot/proxy-pass.conf;
   }

--- a/lp-depot/templates/steam.site.j2
+++ b/lp-depot/templates/steam.site.j2
@@ -10,16 +10,13 @@ server {
   resolver {{ depot_resolvers | join(" ") }};
 
   location /depot {
-    # Cache Location
     proxy_cache steam;
 
-    # No slicing for this site
     include depot/proxy-noslice.conf;
 
     # Ignore upstream Expires header choose use our own
     proxy_ignore_headers Expires;
 
-    # Use proxy_cache method
     include depot/proxy-cache.conf;
     include depot/proxy-pass.conf;
   }

--- a/lp-depot/templates/steam.site.j2
+++ b/lp-depot/templates/steam.site.j2
@@ -10,19 +10,18 @@ server {
   resolver {{ depot_resolvers | join(" ") }};
 
   location /depot {
-    # Cache location
+    # Cache Location
     proxy_cache steam;
 
-    # Cache Settings
-    proxy_cache_key "$uri";
-    proxy_cache_valid 200 7d;
+    # No slicing for this site
+    include depot/proxy-noslice.conf;
+
+    # Ignore upstream Expires header choose use our own
+    proxy_ignore_headers Expires;
 
     # Use proxy_cache method
     include depot/proxy-cache.conf;
     include depot/proxy-pass.conf;
-
-    # Ignore upstream Expires header choose use our own
-    proxy_ignore_headers Expires;
   }
 
   location / {

--- a/lp-depot/templates/uplay.site.j2
+++ b/lp-depot/templates/uplay.site.j2
@@ -1,0 +1,23 @@
+# {{ ansible_managed }}
+
+server {
+  listen 80;
+  server_name .{{ depot_sites.uplay.domains | join(" .") }};
+
+  access_log {{ depot_logdir }}/uplay/depot-access.log depot buffer=128k flush=1m;
+  error_log {{ depot_logdir }}/uplay/depot-error.log;
+
+  resolver {{ depot_resolvers | join(" ") }};
+
+  location / {
+    # Cache Location
+    proxy_cache uplay;
+
+    # Use slicing method for this site
+    include depot/proxy-slice.conf;
+
+    # Use proxy_cache method
+    include depot/proxy-cache.conf;
+    include depot/proxy-pass.conf;
+  }
+}

--- a/lp-depot/templates/uplay.site.j2
+++ b/lp-depot/templates/uplay.site.j2
@@ -13,10 +13,8 @@ server {
     # Cache Location
     proxy_cache uplay;
 
-    # Use slicing method for this site
-    include depot/proxy-slice.conf;
+    include depot/proxy-noslice.conf;
 
-    # Use proxy_cache method
     include depot/proxy-cache.conf;
     include depot/proxy-pass.conf;
   }

--- a/lp-depot/templates/windows.site.j2
+++ b/lp-depot/templates/windows.site.j2
@@ -10,17 +10,11 @@ server {
   resolver {{ depot_resolvers | join(" ") }};
 
   location / {
-    # Request Slicing
-    # Supported in nginx 1.9.8
-    slice 1m;
-
     # Cache Location
     proxy_cache windows;
 
-    # Cache Settings
-    proxy_cache_key   $uri$slice_range;
-    proxy_cache_valid 200 206 7d;
-    proxy_set_header  Range $slice_range;
+    # Use slicing method for this site
+    include depot/proxy-slice.conf;
 
     # Use proxy_cache method
     include depot/proxy-cache.conf;

--- a/lp-ns/defaults/main.yml
+++ b/lp-ns/defaults/main.yml
@@ -41,14 +41,7 @@ ns:
   spoof:
     # Directory to install spoofed zones to
     confdir: /etc/bind/spoof
-    services:
-      twitch:
-        domains:
-          - usher.ttvnw.net
-          - usher.justin.tv
-          - usher.twitch.tv
-          - hls.twitch.tv
-          - hls.ttvnw.net
+    services: {}
 
 depot_sites:
   steam:
@@ -81,7 +74,16 @@ depot_sites:
   riot:
     domains:
       - l3cdn.riotgames.com
+      - worldwide.l3cdn.riotgames.com
       - news.cdn.leagueoflegends.com
+  sony:
+    size: 100g
+    domains:
+      - pls.patch.station.sony.com
+  uplay:
+    size: 100g
+    domains:
+      - cdn.ubi.com
   windows:
     domains:
       - download.windowsupdate.com

--- a/lp-ns/defaults/main.yml
+++ b/lp-ns/defaults/main.yml
@@ -83,7 +83,7 @@ depot_sites:
   uplay:
     size: 100g
     domains:
-      - cdn.ubi.com
+      - uplaypc-s-ubisoft.cdn.ubi.com
   windows:
     domains:
       - download.windowsupdate.com


### PR DESCRIPTION
lp-depot
---
* Keepalive for client connections to the cache (HTTP/1.1) where supported
* Updated Riot domain
* Added Sony and Uplay cache sites
* Moved slice/noslice configuration to their respective includes in `depot/`

lp-base
---
* misc fix to lp-base trying to manage hostnames in LXC containers (DBus not running)