### PR TITLE
lp-base - Add CPU Governor control for baremetal machines.

### DIFF
--- a/lp-base/defaults/main.yml
+++ b/lp-base/defaults/main.yml
@@ -43,6 +43,9 @@ trusted_networks: []
 
 logstash: { }
 
+cpu:
+  governor: performance
+
 kern:
   params:
     - { name: 'net.ipv4.neigh.default.gc_thresh1', value: '2048' }

--- a/lp-base/tasks/cpu.yml
+++ b/lp-base/tasks/cpu.yml
@@ -1,0 +1,12 @@
+- name: CPU | Set Governor persistent for baremetal
+  lineinfile:
+    dest: /etc/default/cpufrequtils
+    line: 'GOVERNOR="{{ cpu.governor }}"'
+    create: yes
+  when: ansible_virtualization_type != 'lxc' and ansible_virtualization_type != 'VMware'
+
+- name: CPU | Set governor at runtime for baremetal
+  shell: "for ((i=0;i<$(nproc);i++)); do cpufreq-set -c $i -r -g {{ cpu.governor }}; done;"
+  args:
+    executable: /bin/bash
+  ignore_errors: True

--- a/lp-base/tasks/main.yml
+++ b/lp-base/tasks/main.yml
@@ -14,6 +14,9 @@
 - include: packages.yml
   tags: [ 'packages' ]
 
+- include: cpu.yml
+  tags: [ 'cpu' ]
+
 - include: time.yml
   tags: [ 'time' ]
 

--- a/lp-base/tasks/packages.yml
+++ b/lp-base/tasks/packages.yml
@@ -84,6 +84,14 @@
   when: ansible_virtualization_type == 'VMware'
   tags: [ 'packages' ]
 
+- name: Global | Baremetal-only packages
+  apt:
+    name: "{{ item }}"
+  with_items:
+    - cpufrequtils
+  when: ansible_virtualization_type != 'lxc' and ansible_virtualization_type != 'VMware'
+  tags: [ 'packages' ]
+
 - name: Global | Networking Packages
   apt:
     name: "{{ item }}"


### PR DESCRIPTION
lp-base - Ignore errors for baremetal that does not have os-control enabled for cpu management

Added CPU governor control for baremetal hosts that have os-control enabled in the bios for cpu power management.

The default setting sets the governor to performance. This makes sure the processor always runs at the maximum non turbo frequency. This prevents having delays that are cause by switching to higher C-States / P-states (going up in frequency and power usage). This is mostly a issue in pre intel skylake architectures.

References:
- [Power Management States: P-States, C-States, and Package C-States | Intel® Software](https://software.intel.com/en-us/articles/power-management-states-p-states-c-states-and-package-c-states)
- [What exactly is a P-state? (Pt. 1) | Intel® Software](https://software.intel.com/en-us/blogs/2008/05/29/what-exactly-is-a-p-state-pt-1)
- [C-states and P-states are very different | Intel® Software](https://software.intel.com/en-us/blogs/2008/03/12/c-states-and-p-states-are-very-different)
- [Examining Intel's New Speed Shift Tech on Skylake: More Responsive Processors | Anandtech](http://www.anandtech.com/show/9751/examining-intel-skylake-speed-shift-more-responsive-processors)
- [Skylake (microarchitecture) | Wikipedia](https://en.wikipedia.org/wiki/Skylake_(microarchitecture))