### PR TITLE
lp-elastic + lp-nginx: Fixed elasticsearch and add htpasswd to lp-nginx

### DIFF
--- a/lp-elastic/defaults/main.yml
+++ b/lp-elastic/defaults/main.yml
@@ -5,4 +5,5 @@ elasticsearch:
   publish_host: '{{ ansible_default_ipv4.address }}'
   tcp_port: 9300
   http_port: 9200
-  memory: 1024m
+  heap: 1g
+  jvm_custom_parameters: ''

--- a/lp-elastic/tasks/elastic.yml
+++ b/lp-elastic/tasks/elastic.yml
@@ -9,17 +9,15 @@
     name: elasticsearch
   tags: [ 'packages' ]
 
-- name: elastic | Set Heap Size
-  lineinfile:
-    line: "ES_HEAP_SIZE={{ elasticsearch.memory | default('1024m') }}"
-    regexp: '^\#?\s?ES_HEAP_SIZE'
-    dest: /etc/default/elasticsearch
-  notify: restart es
-
-- name: elastic | Render Configuration
+- name: elastic | Render elasticsearch.yml
   template:
     src: es.yml.j2
     dest: /etc/elasticsearch/elasticsearch.yml
+
+- name: elastic | Render jvm.options
+  template:
+    src: jvm.options.j2
+    dest: /etc/elasticsearch/jvm.options
   notify: restart es
 
 - name: elastic | Start Service

--- a/lp-elastic/templates/es.yml.j2
+++ b/lp-elastic/templates/es.yml.j2
@@ -4,12 +4,6 @@
 cluster.name: {{ elasticsearch.cluster }}
 node.name: "{{ inventory_hostname }}"
 
-# Indexing/Sharding
-index.number_of_shards: 5
-# We want each index to be replicated on exactly one node
-# Setting this to <es_servers> - 1 ensures green cluster state
-index.number_of_replicas: {{ (groups[elasticsearch_group] | count) - 1 }}
-
 # Networking
 network.bind_host: {{ elasticsearch.bind_host }}
 network.publish_host: {{ elasticsearch.bind_host }}
@@ -25,8 +19,7 @@ http.port: {{ elasticsearch.http_port }}
 
 # Discovery
 discovery.zen.minimum_master_nodes: {{ elasticsearch.min_masters | default('1') }}
-discovery.zen.ping.timeout: {{ elasticsearch.timeout | default('3') }}s
-discovery.zen.ping.multicast.enabled: {{ elasticsearch.multicast | default('false') }}
+discovery.zen.ping_timeout: {{ elasticsearch.timeout | default('3') }}s
 {% if elasticsearch_group is defined and groups[elasticsearch_group] | length > 1 %}
 discovery.zen.ping.unicast.hosts: [
 {% for h in groups[elasticsearch_group] %}

--- a/lp-elastic/templates/jvm.options.j2
+++ b/lp-elastic/templates/jvm.options.j2
@@ -1,0 +1,118 @@
+## JVM configuration
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+{% if elasticsearch.heap is defined %}
+-Xms{{ elasticsearch.heap }}
+-Xmx{{ elasticsearch.heap }}
+{% else %}
+-Xms2g
+-Xmx2g
+{% endif %}
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+-XX:+UseConcMarkSweepGC
+-XX:CMSInitiatingOccupancyFraction=75
+-XX:+UseCMSInitiatingOccupancyOnly
+
+## optimizations
+
+# pre-touch memory pages used by the JVM during initialization
+-XX:+AlwaysPreTouch
+
+## basic
+
+# force the server VM
+-server
+
+# set to headless, just in case
+-Djava.awt.headless=true
+
+# ensure UTF-8 encoding by default (e.g. filenames)
+-Dfile.encoding=UTF-8
+
+# use our provided JNA always versus the system one
+-Djna.nosys=true
+
+# use old-style file permissions on JDK9
+-Djdk.io.permissionsUseCanonicalPath=true
+
+# flags to configure Netty
+-Dio.netty.noUnsafe=true
+-Dio.netty.noKeySetOptimization=true
+-Dio.netty.recycler.maxCapacityPerThread=0
+
+# log4j 2
+-Dlog4j.shutdownHookEnabled=false
+-Dlog4j2.disable.jmx=true
+-Dlog4j.skipJansi=true
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps
+# ensure the directory exists and has sufficient space
+#-XX:HeapDumpPath=${heap.dump.path}
+
+## GC logging
+
+#-XX:+PrintGCDetails
+#-XX:+PrintGCTimeStamps
+#-XX:+PrintGCDateStamps
+#-XX:+PrintClassHistogram
+#-XX:+PrintTenuringDistribution
+#-XX:+PrintGCApplicationStoppedTime
+
+# log GC status to a file with time stamps
+# ensure the directory exists
+#-Xloggc:${loggc}
+
+
+# By default, the GC log file will not rotate.
+# By uncommenting the lines below, the GC log file
+# will be rotated every 128MB at most 32 times.
+#-XX:+UseGCLogFileRotation
+#-XX:NumberOfGCLogFiles=32
+#-XX:GCLogFileSize=128M
+
+# Elasticsearch 5.0.0 will throw an exception on unquoted field names in JSON.
+# If documents were already indexed with unquoted fields in a previous version
+# of Elasticsearch, some operations may throw errors.
+#
+# WARNING: This option will be removed in Elasticsearch 6.0.0 and is provided
+# only for migration purposes.
+#-Delasticsearch.json.allow_unquoted_field_names=true
+{% if elasticsearch.jvm_custom_parameters !='' %}
+{% for item in elasticsearch.jvm_custom_parameters %}
+{{ item }}
+{% endfor %}
+{% endif %}

--- a/lp-nginx/tasks/configure.yml
+++ b/lp-nginx/tasks/configure.yml
@@ -14,6 +14,12 @@
     dest: /etc/nginx/nginx.conf
   notify: reload nginx
 
+- name: Nginx | Render htpasswd
+  template:
+    src: htpasswd.j2
+    dest: /et/nginx/htpasswd
+  notify: reload nginx
+
 - name: Nginx | Render Defaults
   template:
     src: nginx.default.j2

--- a/lp-nginx/tasks/configure.yml
+++ b/lp-nginx/tasks/configure.yml
@@ -14,6 +14,13 @@
     dest: /etc/nginx/nginx.conf
   notify: reload nginx
 
+- name: Nginx | Render htpasswd
+  template:
+    src: htpasswd.j2
+    dest: /etc/nginx/htpasswd
+  notify: reload nginx
+  when: nginx_users is defined
+
 - name: Nginx | Render Defaults
   template:
     src: nginx.default.j2

--- a/lp-nginx/templates/htpasswd.j2
+++ b/lp-nginx/templates/htpasswd.j2
@@ -1,0 +1,3 @@
+{% for key, value in nginx_users.iteritems() -%}
+  {{ key }}:{{ value }}
+{%- endfor %}


### PR DESCRIPTION
Fixed elasticsearch role to work with 5.1 and later.

Also added a global htpasswd file possibility to lp-nginx,